### PR TITLE
Update Dockerfile.exporter

### DIFF
--- a/docker/exporter/Dockerfile.exporter
+++ b/docker/exporter/Dockerfile.exporter
@@ -1,7 +1,8 @@
-FROM python
+FROM python:alpine
 LABEL author="Gleb Tcivie"
 
 WORKDIR /app
+RUN  apk add --update --no-cache gcc libc-dev libffi-dev
 COPY ../../requirements.txt .
 COPY ../../.env .
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
Redid the docker file for the exporter to cutdown on some of the overhead. The original container size was roughly 1.12GB where this cuts it down to about 306MB. Helps to cut down on space used on space limited devices (Raspberry Pi CM4's).

![image](https://github.com/user-attachments/assets/39142d60-cf09-46c7-92cf-6ed55b5c13ce)

